### PR TITLE
A couple minor fixes

### DIFF
--- a/src/audio.c
+++ b/src/audio.c
@@ -637,7 +637,6 @@ int start_portaudio(int device, int *nominal_sample_rate, double *real_sample_ra
 	if(testing) {
 		*nominal_sample_rate = PA_SAMPLE_RATE;
 		*real_sample_rate = PA_SAMPLE_RATE;
-		goto end;
 	}
 #endif
 
@@ -661,9 +660,6 @@ int start_portaudio(int device, int *nominal_sample_rate, double *real_sample_ra
 	if(err!=paNoError && err!=1)
 		goto error;
 
-#ifdef DEBUG
-end:
-#endif
 	debug("sample rate: nominal = %d real = %f\n",*nominal_sample_rate,*real_sample_rate);
 
 	return 0;

--- a/src/output_panel.c
+++ b/src/output_panel.c
@@ -772,7 +772,7 @@ static gboolean paperstrip_draw_event(GtkWidget *widget, cairo_t *c, struct outp
 
 	double display_offset = chart_width/2; // Value used if no anchor found
 	double offsets[snst->events_count];
-	if (snst->events_count) {
+	if (snst->events_count > 0) {
 		double accumulated_offset = 0.0;
 		uint64_t prev_event = snst->events[snst->events_wp]; // Start with first event
 		for (i = snst->events_count; i > 0; i--) { // Scan order is newest to oldest


### PR DESCRIPTION
1. The patch talked about in #10 
2. Warns about an uninit value. This is because:

1. The if statement here
https://github.com/xyzzy42/tg/blob/a72f90535574de7ec8dc80d71cd740446ea9d323/src/output_panel.c#L775

Means "events_count is non-zero", and since the type is a signed integer, it means that the for loop on line 778 could potentially never run, leaving `offsets` uninit here:
https://github.com/xyzzy42/tg/blob/a72f90535574de7ec8dc80d71cd740446ea9d323/src/output_panel.c#L796

Could also remove the surrounding if statement, it's not really needed except for setting `anchor_offset`. 