### PR TITLE
Fix crash clearing filter list when filter graph is disabled

### DIFF
--- a/src/filter_interface.c
+++ b/src/filter_interface.c
@@ -421,7 +421,8 @@ static void filter_graph_toggled(GtkToggleButton *button, FilterDialogPrivate* p
 		filter_graph_update(priv, filter_selection_to_row(priv));
 	} else {
 		priv->graph_updated = true;
-		gtk_image_clear(priv->image);
+		if (priv->image)
+			gtk_image_clear(priv->image);
 	}
 }
 
@@ -997,7 +998,8 @@ static void filter_selected(GtkTreeSelection* selection, FilterDialogPrivate* pr
 		priv->selection = NULL;
 		gtk_widget_set_sensitive(priv->editframe, FALSE);
 		if (!priv->fullchain) {
-			gtk_image_clear(priv->image);
+			if (priv->image)
+				gtk_image_clear(priv->image);
 			priv->graph_updated = true;
 		}
 		priv->edit_updated = false;

--- a/src/filter_interface.c
+++ b/src/filter_interface.c
@@ -421,8 +421,7 @@ static void filter_graph_toggled(GtkToggleButton *button, FilterDialogPrivate* p
 		filter_graph_update(priv, filter_selection_to_row(priv));
 	} else {
 		priv->graph_updated = true;
-		if (priv->image)
-			gtk_image_clear(priv->image);
+		gtk_image_clear(priv->image);
 	}
 }
 
@@ -997,11 +996,12 @@ static void filter_selected(GtkTreeSelection* selection, FilterDialogPrivate* pr
 		gtk_tree_path_free(priv->selection);
 		priv->selection = NULL;
 		gtk_widget_set_sensitive(priv->editframe, FALSE);
+#if HAVE_FILTERGRAPH
 		if (!priv->fullchain) {
-			if (priv->image)
-				gtk_image_clear(priv->image);
+			gtk_image_clear(priv->image);
 			priv->graph_updated = true;
 		}
+#endif
 		priv->edit_updated = false;
 	}
 


### PR DESCRIPTION
filter_selected() and filter_graph_toggled() call gtk_image_clear() on priv->image whenever the selection is cleared or the graph is toggled off.  But priv->image is only created when HAVE_FILTERGRAPH is enabled; in builds without it the pointer is NULL, so gtk_image_clear(NULL) dereferences a NULL pointer and crashes.

This is reachable in a normal build by removing the last filter from the chain (which clears the selection).  Guard both calls with a NULL check.