### PR TITLE
Fix swapped _aligned_malloc() arguments on Windows/MinGW

### DIFF
--- a/src/tppm.c
+++ b/src/tppm.c
@@ -265,7 +265,9 @@ struct tppm* tppm_init(unsigned chunk_size, unsigned max_age)
 		return NULL;
 	const size_t bufsize = chunk_size * sizeof(*tppm->buffer);
 #ifdef HAVE__ALIGNED_MALLOC
-	tppm->buffer = _aligned_malloc(32, (bufsize + 31) & ~0x1f);
+	/* _aligned_malloc() takes (size, alignment), the reverse of C11
+	 * aligned_alloc(alignment, size). */
+	tppm->buffer = _aligned_malloc((bufsize + 31) & ~0x1f, 32);
 #else
 	tppm->buffer = aligned_alloc(32, (bufsize + 31) & ~0x1f);
 #endif


### PR DESCRIPTION
tppm_init() allocates its aligned buffer with the MinGW _aligned_malloc() in the HAVE__ALIGNED_MALLOC branch, but the call passes the arguments in C11 aligned_alloc() order: _aligned_malloc(32, size). MSVCRT's signature is _aligned_malloc(size_t size, size_t alignment), so the alignment argument receives the buffer size (e.g. 17664), which is not a power of two. _aligned_malloc() rejects it and returns NULL, so on Windows the true peak meter fails to initialise ('Unable to init tppm system') and the feature is unavailable.

Swap the arguments to match the _aligned_malloc() signature.

Fixes #22 